### PR TITLE
CI: use latest releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
 
 env:
   matrix:
-  - ANSIBLE_REF='ansible==2.5.0' BASE_IMAGE=ubuntu:xenial
-  - ANSIBLE_REF='ansible==2.5.0' BASE_IMAGE=debian:stretch
+  - ANSIBLE_REF='ansible<2.6' BASE_IMAGE=ubuntu:xenial
+  - ANSIBLE_REF='ansible<2.6' BASE_IMAGE=debian:stretch
   - ANSIBLE_REF='ansible<2.5' BASE_IMAGE=ubuntu:xenial
   - ANSIBLE_REF='ansible<2.5' BASE_IMAGE=debian:stretch
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ dist: trusty
 language: python
 python:
 - '2.7'
+- '3.6'
 
 env:
-  matrix:
-  - ANSIBLE_REF='ansible<2.6' BASE_IMAGE=ubuntu:xenial
-  - ANSIBLE_REF='ansible<2.6' BASE_IMAGE=debian:stretch
-  - ANSIBLE_REF='ansible<2.5' BASE_IMAGE=ubuntu:xenial
-  - ANSIBLE_REF='ansible<2.5' BASE_IMAGE=debian:stretch
+- ANSIBLE_REF='ansible<2.6' BASE_IMAGE=ubuntu:xenial
+- ANSIBLE_REF='ansible<2.6' BASE_IMAGE=debian:stretch
+- ANSIBLE_REF='ansible<2.5' BASE_IMAGE=ubuntu:xenial
+- ANSIBLE_REF='ansible<2.5' BASE_IMAGE=debian:stretch
 
 install:
   - travis_retry pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
- ansible 2.5.X (molecule incompatibility fixed in 2.13.1)
- Python 3.6 (supported since molecule 2.13.1)