### PR TITLE
Doc: fix indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,15 @@ Usage
 Add the role to your playbook :
 
 ```yaml
-role: ansible-role-jmx-datadog
-user: username
-password: changeit
-jvm_user: nova # defaults to nova
-jvm_group: nova # defaults to nova
-jvm_user_id: 1000 # optional
-jvm_group_id: 1000 # optional
-
+roles:
+  - role: ansible-role-jmx-datadog
+    vars:
+      user: username
+      password: changeit
+      jvm_user: nova # defaults to nova
+      jvm_group: nova # defaults to nova
+      jvm_user_id: 1000 # optional
+      jvm_group_id: 1000 # optional
 ```
 
 `user` and `password` are the username/password pair for JMX (with readonly access).
@@ -30,21 +31,23 @@ jvm_group_id: 1000 # optional
 You may want to add the [Datadog Ansible Role](https://github.com/DataDog/ansible-datadog) too :
 
 ```yaml
-role: Datadog.datadog
-become: yes
-datadog_api_key: "{{ vault_datadog_api_key }}"
-datadog_agent_version: "1:6.1.4-1"
-datadog_config:
-    tags: "env:{{ inventory_dir | basename }}"
-datadog_checks:
-    jmx:
-        init_config:
-        instances:
+roles:
+  - role: Datadog.datadog
+    become: yes
+    vars:
+      datadog_api_key: "{{ vault_datadog_api_key }}"
+      datadog_agent_version: "1:6.1.4-1"
+      datadog_config:
+        tags: "env:{{ inventory_dir | basename }}"
+      datadog_checks:
+        jmx:
+          init_config:
+          instances:
             - host: localhost
-                port: 7199
-                user: username
-                password: changeit
-                name: instance-name-on-datadog-interface
+              port: 7199
+              user: username
+              password: changeit
+              name: instance-name-on-datadog-interface
 ```
 
 And the following JVM parameters :

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Overview
 --------
-Ansible role to setup JMX credentials and to add Datadog java agent. 
+Ansible role to setup JMX credentials and to add Datadog java agent.
 
 Usage
 -----
@@ -25,7 +25,7 @@ roles:
 
 `user` and `password` are the username/password pair for JMX (with readonly access).
 
-`jvm_user` and `jvm_group` are the user/group who run the jvm 
+`jvm_user` and `jvm_group` are the user/group who run the jvm
 (change access rights on default `jmxremote.password` and `jmxremote.access` files).
 
 You may want to add the [Datadog Ansible Role](https://github.com/DataDog/ansible-datadog) too :

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -4,7 +4,8 @@
   become: yes
   roles:
     - role: ansible-role-jmx-datadog
-      user: jmxuser
-      password: test123abc
-      jvm_user: root
-      jvm_group: root
+      vars:
+        user: jmxuser
+        password: test123abc
+        jvm_user: root
+        jvm_group: root


### PR DESCRIPTION
- fix indentation in documentation
- don't mix keywords and variables
- remove trailing spaces