### PR TITLE
Support Ansible check mode

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -6,7 +6,6 @@
     - role: peopledoc.java
     - role: ansible-role-jmx-datadog
       vars:
-        datadog_skip_running_check: true
         jmx_instances:
           - port: 7199
             user: username

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -6,6 +6,7 @@
     - role: peopledoc.java
     - role: ansible-role-jmx-datadog
       vars:
+        datadog_skip_running_check: true
         jmx_instances:
           - port: 7199
             user: username
@@ -23,6 +24,6 @@
             name: test
 
         datadog_api_key: apikey
-        datadog_version: "6.3.1"
+        datadog_version: "6.8.0"
         datadog_config:
           tags: env:testing

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -52,7 +52,7 @@ def test_datadog_agent_installed(host):
     assert host.exists("datadog-agent")
     cmd = host.run("datadog-agent version")
     assert cmd.rc == 0
-    assert "Agent 6.3.1" in cmd.stdout
+    assert "Agent 6.8.0" in cmd.stdout
 
 
 def test_datadog_yaml(host):

--- a/molecule/no_java_integration/playbook.yml
+++ b/molecule/no_java_integration/playbook.yml
@@ -6,6 +6,7 @@
     - role: peopledoc.java
     - role: ansible-role-jmx-datadog
       vars:
+        datadog_skip_running_check: true
         user: jmxuser
         password: test123abc
         jvm_user: testuser
@@ -18,7 +19,7 @@
             name: test
 
         datadog_api_key: apikey
-        datadog_version: "6.3.1"
+        datadog_version: "6.8.0"
         datadog_java_integration: false
         datadog_config:
           tags: env:testing

--- a/molecule/no_java_integration/playbook.yml
+++ b/molecule/no_java_integration/playbook.yml
@@ -6,7 +6,6 @@
     - role: peopledoc.java
     - role: ansible-role-jmx-datadog
       vars:
-        datadog_skip_running_check: true
         user: jmxuser
         password: test123abc
         jvm_user: testuser

--- a/molecule/no_java_integration/tests/test_no_java_integration.py
+++ b/molecule/no_java_integration/tests/test_no_java_integration.py
@@ -50,7 +50,7 @@ def test_datadog_agent_installed(host):
     assert host.exists("datadog-agent")
     cmd = host.run("datadog-agent version")
     assert cmd.rc == 0
-    assert "Agent 6.3.1" in cmd.stdout
+    assert "Agent 6.8.0" in cmd.stdout
 
 
 def test_datadog_yaml(host):

--- a/molecule/no_jmx_instances/playbook.yml
+++ b/molecule/no_jmx_instances/playbook.yml
@@ -6,7 +6,6 @@
     - role: peopledoc.java
     - role: ansible-role-jmx-datadog
       vars:
-        datadog_skip_running_check: true
         user: jmxuser
         password: test123abc
         jvm_user: root

--- a/molecule/no_jmx_instances/playbook.yml
+++ b/molecule/no_jmx_instances/playbook.yml
@@ -6,6 +6,7 @@
     - role: peopledoc.java
     - role: ansible-role-jmx-datadog
       vars:
+        datadog_skip_running_check: true
         user: jmxuser
         password: test123abc
         jvm_user: root
@@ -18,6 +19,6 @@
             name: test
 
         datadog_api_key: apikey
-        datadog_version: "6.3.1"
+        datadog_version: "6.8.0"
         datadog_config:
           tags: env:testing

--- a/molecule/no_jmx_instances/tests/test_no_jmx_instances.py
+++ b/molecule/no_jmx_instances/tests/test_no_jmx_instances.py
@@ -26,7 +26,7 @@ def test_datadog_agent_installed(host):
     assert host.exists("datadog-agent")
     cmd = host.run("datadog-agent version")
     assert cmd.rc == 0
-    assert "Agent 6.3.1" in cmd.stdout
+    assert "Agent 6.8.0" in cmd.stdout
 
 
 def test_datadog_yaml(host):

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,21 +69,22 @@
 
 - name: Get JAVA_HOME path from java bin path
   set_fact:
-    JAVA_HOME: "{{ alternatives_java_path.replace('/bin/java', '') }}"
+    JAVA_HOME: "{{ alternatives_java_path.replace('/bin/java', '') if alternatives_java_path.stat.exists else '' }}"
   when: java_path.stdout is not defined or java_path.stdout == ""
 
 - name: Stat $JAVA_HOME/jre/lib/management
   stat:
-    path: "{{ JAVA_HOME }}/jre/lib/management/"
+    path: "{{ JAVA_HOME }}/jre/lib/management"
   register: java_path_test
 
 - name: Test $JAVA_HOME/jre/lib/management existence
   fail:
     msg: "JRE directory not found."
-  when: not java_path_test.stat.exists
+  when: not java_path_test.stat.exists and not ansible_check_mode
 
 - vars:
     management_path: "{{ JAVA_HOME }}/jre/lib/management/"
+  when: not ansible_check_mode
   block:
     - name: username/password in jmxremote.password
       lineinfile:
@@ -135,7 +136,7 @@
   get_url:
     url: "https://search.maven.org/classic/remote_content?g=com.datadoghq&a=dd-java-agent&v={{ datadog_java_agent_version }}"
     dest: /usr/local/bin/dd-java-agent.jar
-  when: datadog_java_integration
+  when: datadog_java_integration and not ansible_check_mode
 
 - name: Register jvm options for DataDog as string
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,7 +69,7 @@
 
 - name: Get JAVA_HOME path from java bin path
   set_fact:
-    JAVA_HOME: "{{ alternatives_java_path.replace('/bin/java', '') if alternatives_java_path.stat.exists else '' }}"
+    JAVA_HOME: "{{ alternatives_java_path.stat.path.replace('/bin/java', '') if alternatives_java_path.stat.exists else '' }}"
   when: java_path.stdout is not defined or java_path.stdout == ""
 
 - name: Stat $JAVA_HOME/jre/lib/management

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,7 +69,7 @@
 
 - name: Get JAVA_HOME path from java bin path
   set_fact:
-    JAVA_HOME: "{{ alternatives_java_path.stat.path.replace('/bin/java', '') if alternatives_java_path.stat.exists else '' }}"
+    JAVA_HOME: "{{ alternatives_java_path.stat.lnk_source.replace('/bin/java', '') if alternatives_java_path.stat.exists else '' }}"
   when: java_path.stdout is not defined or java_path.stdout == ""
 
 - name: Stat $JAVA_HOME/jre/lib/management


### PR DESCRIPTION
Motivations:
* Be able to include this role in playbooks running in check mode

Modifications:
* Upgrade default tested datadog-agent version to 6.8.0
* Skip some incompatible tasks in check mode
* Workaround a templating issue where a string become a dict
  in check mode.